### PR TITLE
Feature/1.9.7

### DIFF
--- a/module/deployment/main.tf
+++ b/module/deployment/main.tf
@@ -21,6 +21,7 @@ resource "null_resource" "add_spaceone_repo" {
     command = <<EOT
       helm repo add spaceone https://spaceone-dev.github.io/charts --repository-config ${path.module}/../../data/helm/config/repositories.yaml --repository-cache ${path.module}/../../data/helm/cache/repository
       helm repo update --repository-config ${path.module}/../../data/helm/config/repositories.yaml --repository-cache ${path.module}/../../data/helm/cache/repository
+      helm repo update
       sleep 5
     EOT
   }

--- a/module/deployment/tmpl/cloud/frontend.tpl
+++ b/module/deployment/tmpl/cloud/frontend.tpl
@@ -5,7 +5,7 @@ console:
   replicas: 2
   image:
       name: public.ecr.aws/megazone/spaceone/console
-      version: 1.9.6
+      version: 1.9.7
   imagePullPolicy: IfNotPresent
 
   # For production.json (nodejs)
@@ -59,7 +59,7 @@ console-api:
   replicas: 2
   image:
       name: public.ecr.aws/megazone/spaceone/console-api
-      version: 1.9.6
+      version: 1.9.7
   imagePullPolicy: IfNotPresent
 
 ###############################################

--- a/module/deployment/tmpl/cloud/frontend.tpl
+++ b/module/deployment/tmpl/cloud/frontend.tpl
@@ -5,7 +5,7 @@ console:
   replicas: 2
   image:
       name: public.ecr.aws/megazone/spaceone/console
-      version: 1.9.7
+      version: 1.9.7.10
   imagePullPolicy: IfNotPresent
 
   # For production.json (nodejs)
@@ -59,7 +59,7 @@ console-api:
   replicas: 2
   image:
       name: public.ecr.aws/megazone/spaceone/console-api
-      version: 1.9.7
+      version: 1.9.7.1
   imagePullPolicy: IfNotPresent
 
 ###############################################

--- a/module/deployment/tmpl/cloud/minimal.tpl
+++ b/module/deployment/tmpl/cloud/minimal.tpl
@@ -17,7 +17,7 @@ console:
   replicas: 1
   image:
       name: spaceone/console
-      version: 1.9.7
+      version: 1.9.7.10
   imagePullPolicy: IfNotPresent
 
   production_json:
@@ -38,7 +38,7 @@ console-api:
   replicas: 1
   image:
       name: spaceone/console-api
-      version: 1.9.7
+      version: 1.9.7.1
   imagePullPolicy: IfNotPresent
 
   production_json:
@@ -73,7 +73,7 @@ identity:
     replicas: 1
     image:
       name: spaceone/identity
-      version: 1.9.7
+      version: 1.9.7.3
     imagePullPolicy: Always
 
     application_grpc:
@@ -122,7 +122,7 @@ secret:
     replicas: 1
     image:
       name: spaceone/secret
-      version: 1.9.7
+      version: 1.9.7.1
     application_grpc:
         BACKEND: ConsulConnector
         CONNECTORS:
@@ -139,7 +139,7 @@ repository:
     replicas: 1
     image:
       name: spaceone/repository
-      version: 1.9.7
+      version: 1.9.7.1
     application_grpc:
         ROOT_TOKEN_INFO:
             protocol: consul
@@ -152,7 +152,7 @@ plugin:
     replicas: 1
     image:
       name: spaceone/plugin
-      version: 1.9.7
+      version: 1.9.7.2
  
     scheduler: false
     worker: false
@@ -168,7 +168,7 @@ config:
     replicas: 1
     image:
       name: spaceone/config
-      version: 1.9.7
+      version: 1.9.7.1
 
 inventory:
     enabled: true
@@ -176,7 +176,7 @@ inventory:
     replicas_worker: 1
     image:
       name: spaceone/inventory
-      version: 1.9.7
+      version: 1.9.7.2
     scheduler: true
     worker: true
     application_grpc:
@@ -220,7 +220,7 @@ monitoring:
     replicas_worker: 1
     image:
       name: spaceone/monitoring
-      version: 1.9.7
+      version: 1.9.7.1
     application_grpc:
       WEBHOOK_DOMAIN: https://monitoring-webhook.example.com
       TOKEN_INFO:
@@ -276,7 +276,7 @@ statistics:
     replicas: 1
     image:
       name: spaceone/statistics
-      version: 1.9.7
+      version: 1.9.7.1
  
     scheduler: false
     worker: false
@@ -292,7 +292,7 @@ notification:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/notification
-      version: 1.9.7 
+      version: 1.9.7.1
     application_grpc:
         INSTALLED_PROTOCOL_PLUGINS:
           - name: Slack
@@ -324,7 +324,7 @@ cost-analysis:
     replicas_worker: 2
     image:
       name: public.ecr.aws/megazone/spaceone/cost-analysis
-      version: 1.9.7
+      version: 1.9.7.1
 
     # Overwrite scheduler config
     application_scheduler:
@@ -332,15 +332,13 @@ cost-analysis:
 
     application_grpc:
         DEFAULT_EXCHANGE_RATE:
-            KRW: 1178.7
-            JPY: 114.2
-            CNY: 6.3
+            KRW: 1242.7
+            JPY: 129.8
 
     application_worker:
         DEFAULT_EXCHANGE_RATE:
-            KRW: 1178.7
-            JPY: 114.2
-            CNY: 6.3
+            KRW: 1242.7
+            JPY: 129.8
 
     volumeMounts:
         application: []

--- a/module/deployment/tmpl/cloud/minimal.tpl
+++ b/module/deployment/tmpl/cloud/minimal.tpl
@@ -17,7 +17,7 @@ console:
   replicas: 1
   image:
       name: spaceone/console
-      version: 1.9.6
+      version: 1.9.7
   imagePullPolicy: IfNotPresent
 
   production_json:
@@ -38,7 +38,7 @@ console-api:
   replicas: 1
   image:
       name: spaceone/console-api
-      version: 1.9.6
+      version: 1.9.7
   imagePullPolicy: IfNotPresent
 
   production_json:
@@ -73,7 +73,7 @@ identity:
     replicas: 1
     image:
       name: spaceone/identity
-      version: 1.9.6
+      version: 1.9.7
     imagePullPolicy: Always
 
     application_grpc:
@@ -109,22 +109,20 @@ identity:
       - service: config
         name: Config Service
         endpoint: grpc://config:50051/v1
-      - service: power_scheduler
-        name: Power Scheduler Service
-        endpoint: grpc://power-scheduler:50051/v1
       - service: statistics
         name: Statistics Service
         endpoint: grpc://statistics:50051/v1
-      - service: billing
-        name: Billing Service
-        endpoint: grpc://billing:50051/v1
+      - service: cost-analysis
+        name: Cost Analysis Service
+        endpoint: grpc://cost-analysis:50051/v1
+
 
 secret:
     enabled: true
     replicas: 1
     image:
       name: spaceone/secret
-      version: 1.9.6
+      version: 1.9.7
     application_grpc:
         BACKEND: ConsulConnector
         CONNECTORS:
@@ -141,7 +139,7 @@ repository:
     replicas: 1
     image:
       name: spaceone/repository
-      version: 1.9.6
+      version: 1.9.7
     application_grpc:
         ROOT_TOKEN_INFO:
             protocol: consul
@@ -154,7 +152,7 @@ plugin:
     replicas: 1
     image:
       name: spaceone/plugin
-      version: 1.9.6
+      version: 1.9.7
  
     scheduler: false
     worker: false
@@ -170,7 +168,7 @@ config:
     replicas: 1
     image:
       name: spaceone/config
-      version: 1.9.6
+      version: 1.9.7
 
 inventory:
     enabled: true
@@ -178,7 +176,7 @@ inventory:
     replicas_worker: 1
     image:
       name: spaceone/inventory
-      version: 1.9.6
+      version: 1.9.7
     scheduler: true
     worker: true
     application_grpc:
@@ -222,7 +220,7 @@ monitoring:
     replicas_worker: 1
     image:
       name: spaceone/monitoring
-      version: 1.9.6
+      version: 1.9.7
     application_grpc:
       WEBHOOK_DOMAIN: https://monitoring-webhook.example.com
       TOKEN_INFO:
@@ -278,7 +276,7 @@ statistics:
     replicas: 1
     image:
       name: spaceone/statistics
-      version: 1.9.6
+      version: 1.9.7
  
     scheduler: false
     worker: false
@@ -289,19 +287,12 @@ statistics:
                 host: spaceone-consul-server
             uri: root/api_key/TOKEN
 
-billing:
-    enabled: true
-    replicas: 1
-    image:
-      name: spaceone/billing
-      version: 1.9.6
-
 notification:
     enabled: true
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/notification
-      version: 1.9.6 
+      version: 1.9.7 
     application_grpc:
         INSTALLED_PROTOCOL_PLUGINS:
           - name: Slack
@@ -333,7 +324,7 @@ cost-analysis:
     replicas_worker: 2
     image:
       name: public.ecr.aws/megazone/spaceone/cost-analysis
-      version: 1.9.6
+      version: 1.9.7
 
     # Overwrite scheduler config
     application_scheduler:
@@ -367,7 +358,7 @@ supervisor:
     enabled: true
     image:
       name: spaceone/supervisor
-      version: 1.9.6
+      version: 1.9.7
     application: {}
     application_scheduler:
         NAME: root
@@ -449,15 +440,12 @@ global:
             StatisticsConnector:
                 endpoint:
                     v1: grpc://statistics:50051
-            BillingConnector:
-                endpoint:
-                    v1: grpc://billing:50051
             NotificationConnector:
                 endpoint:
                     v1: grpc://notification:50051
-            PowerSchedulerConnector:
+            CostAnalysisConnector:
                 endpoint:
-                    v1: grpc://power-scheduler:50051
+                    v1: grpc://cost-analysis:50051/v1
         CACHES:
             default:
                 backend: spaceone.core.cache.redis_cache.RedisCache

--- a/module/deployment/tmpl/cloud/minimal.tpl
+++ b/module/deployment/tmpl/cloud/minimal.tpl
@@ -2,14 +2,22 @@ enabled: true
 
 mongodb:
     enabled: true
+    pvc:
+        storageClassName: null # You must specify a storage class name. Otherwise, the mongodb pod will not use pvc.
+        accessModes: 
+            - "ReadWriteOnce"
+        requests:
+            storage: 8Gi
 redis:
     enabled: true
 consul:
     enabled: true
     server:
         replicas: 1
+        #storageClass: null
     ui:
         enabled: false
+
 console:
   enabled: true
   developer: false

--- a/module/deployment/tmpl/cloud/values.tpl
+++ b/module/deployment/tmpl/cloud/values.tpl
@@ -13,7 +13,7 @@ identity:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/identity
-      version: 1.9.6
+      version: 1.9.7
 
     pod:
         spec: {}
@@ -23,7 +23,7 @@ secret:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/secret
-      version: 1.9.6
+      version: 1.9.7
     application_grpc:
 #        BACKEND: ConsulConnector
 #        CONNECTORS:
@@ -49,14 +49,14 @@ repository:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/repository
-      version: 1.9.6
+      version: 1.9.7
 
 plugin:
     enabled: true
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/plugin
-      version: 1.9.6
+      version: 1.9.7
  
     scheduler: true
     worker: true
@@ -76,7 +76,7 @@ config:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/config
-      version: 1.9.6
+      version: 1.9.7
 
     pod:
         spec: {}
@@ -87,7 +87,7 @@ inventory:
     replicas_worker: 2
     image:
       name: public.ecr.aws/megazone/spaceone/inventory
-      version: 1.9.6
+      version: 1.9.7
     scheduler: true
     worker: true
     application_grpc:
@@ -165,7 +165,7 @@ monitoring:
     replicas_worker: 1
     image:
       name: public.ecr.aws/megazone/spaceone/monitoring
-      version: 1.9.6
+      version: 1.9.7
     application_grpc:
       WEBHOOK_DOMAIN: https://${monitoring_webhook_domain}
 #      TOKEN: __CHANGE_YOUR_ROOT_TOKEN___
@@ -237,7 +237,7 @@ statistics:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/statistics
-      version: 1.9.6
+      version: 1.9.7
  
     scheduler: true
     worker: true
@@ -252,22 +252,12 @@ statistics:
     pod:
         spec: {}
 
-billing:
-    enabled: true
-    replicas: 1
-    image:
-      name: public.ecr.aws/megazone/spaceone/billing
-      version: 1.9.6
-
-    pod:
-        spec: {}
-
 notification:
     enabled: true
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/notification
-      version: 1.9.6
+      version: 1.9.7
     application_grpc:
         INSTALLED_PROTOCOL_PLUGINS:
           - name: Slack
@@ -302,7 +292,7 @@ cost-analysis:
     replicas_worker: 2
     image:
       name: public.ecr.aws/megazone/spaceone/cost-analysis
-      version: 1.9.6
+      version: 1.9.7
 
     # Overwrite scheduler config
     application_scheduler:
@@ -339,7 +329,7 @@ supervisor:
     enabled: true
     image:
       name: public.ecr.aws/megazone/spaceone/supervisor
-      version: 1.9.6
+      version: 1.9.7
     application: {}
     application_scheduler:
         NAME: root
@@ -380,7 +370,7 @@ ingress:
 spaceone-initializer:
     enabled: false
     image:
-        version: 1.9.6
+        version: 1.9.7
 
 domain-initialzer:
     enabled: false
@@ -432,18 +422,12 @@ global:
             StatisticsConnector:
                 endpoint:
                     v1: grpc://statistics:50051
-            BillingConnector:
-                endpoint:
-                    v1: grpc://billing:50051
             NotificationConnector:
                 endpoint:
                     v1: grpc://notification:50051
-            PowerSchedulerConnector:
+            CostAnalysisConnector:
                 endpoint:
-                    v1: grpc://power-scheduler:50051
-            SpotAutomationConnector:
-                endpoint:
-                    v1: grpc://spot-automation:50051
+                    v1: grpc://cost-analysis:50051/v1
         CACHES:
             default:
                 backend: spaceone.core.cache.redis_cache.RedisCache

--- a/module/deployment/tmpl/cloud/values.tpl
+++ b/module/deployment/tmpl/cloud/values.tpl
@@ -3,10 +3,21 @@ enabled: true
 # Service
 mongodb:
     enabled: false
+    pvc:
+        storageClassName: null # You must specify a storage class name. Otherwise, the mongodb pod will not use pvc.
+        accessModes: 
+            - "ReadWriteOnce"
+        requests:
+            storage: 8Gi
 redis:
     enabled: true
 consul:
     enabled: true
+    server:
+        replicas: 3
+        #storageClass: null
+    ui:
+        enabled: false
 
 identity:
     enabled: true

--- a/module/deployment/tmpl/cloud/values.tpl
+++ b/module/deployment/tmpl/cloud/values.tpl
@@ -13,7 +13,7 @@ identity:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/identity
-      version: 1.9.7
+      version: 1.9.7.3
 
     pod:
         spec: {}
@@ -23,7 +23,7 @@ secret:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/secret
-      version: 1.9.7
+      version: 1.9.7.1
     application_grpc:
 #        BACKEND: ConsulConnector
 #        CONNECTORS:
@@ -49,14 +49,14 @@ repository:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/repository
-      version: 1.9.7
+      version: 1.9.7.1
 
 plugin:
     enabled: true
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/plugin
-      version: 1.9.7
+      version: 1.9.7.2
  
     scheduler: true
     worker: true
@@ -76,7 +76,7 @@ config:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/config
-      version: 1.9.7
+      version: 1.9.7.1
 
     pod:
         spec: {}
@@ -87,7 +87,7 @@ inventory:
     replicas_worker: 2
     image:
       name: public.ecr.aws/megazone/spaceone/inventory
-      version: 1.9.7
+      version: 1.9.7.2
     scheduler: true
     worker: true
     application_grpc:
@@ -165,7 +165,7 @@ monitoring:
     replicas_worker: 1
     image:
       name: public.ecr.aws/megazone/spaceone/monitoring
-      version: 1.9.7
+      version: 1.9.7.1
     application_grpc:
       WEBHOOK_DOMAIN: https://${monitoring_webhook_domain}
 #      TOKEN: __CHANGE_YOUR_ROOT_TOKEN___
@@ -237,7 +237,7 @@ statistics:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/statistics
-      version: 1.9.7
+      version: 1.9.7.1
  
     scheduler: true
     worker: true
@@ -257,7 +257,7 @@ notification:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/notification
-      version: 1.9.7
+      version: 1.9.7.1
     application_grpc:
         INSTALLED_PROTOCOL_PLUGINS:
           - name: Slack
@@ -292,7 +292,7 @@ cost-analysis:
     replicas_worker: 2
     image:
       name: public.ecr.aws/megazone/spaceone/cost-analysis
-      version: 1.9.7
+      version: 1.9.7.1
 
     # Overwrite scheduler config
     application_scheduler:
@@ -300,15 +300,13 @@ cost-analysis:
 
     application_grpc:
         DEFAULT_EXCHANGE_RATE:
-            KRW: 1178.7
-            JPY: 114.2
-            CNY: 6.3
+            KRW: 1242.7
+            JPY: 129.8
 
     application_worker:
         DEFAULT_EXCHANGE_RATE:
-            KRW: 1178.7
-            JPY: 114.2
-            CNY: 6.3
+            KRW: 1242.7
+            JPY: 129.8
 
     volumeMounts:
         application: []

--- a/module/deployment/tmpl/internal/frontend.tpl
+++ b/module/deployment/tmpl/internal/frontend.tpl
@@ -5,7 +5,7 @@ console:
   replicas: 2
   image:
       name: public.ecr.aws/megazone/spaceone/console
-      version: 1.9.6
+      version: 1.9.7
   imagePullPolicy: IfNotPresent
 
   # For production.json (nodejs)
@@ -59,7 +59,7 @@ console-api:
   replicas: 2
   image:
       name: public.ecr.aws/megazone/spaceone/console-api
-      version: 1.9.6
+      version: 1.9.7
   imagePullPolicy: IfNotPresent
 
 ###############################################

--- a/module/deployment/tmpl/internal/frontend.tpl
+++ b/module/deployment/tmpl/internal/frontend.tpl
@@ -5,7 +5,7 @@ console:
   replicas: 2
   image:
       name: public.ecr.aws/megazone/spaceone/console
-      version: 1.9.7
+      version: 1.9.7.10
   imagePullPolicy: IfNotPresent
 
   # For production.json (nodejs)
@@ -59,7 +59,7 @@ console-api:
   replicas: 2
   image:
       name: public.ecr.aws/megazone/spaceone/console-api
-      version: 1.9.7
+      version: 1.9.7.1
   imagePullPolicy: IfNotPresent
 
 ###############################################

--- a/module/deployment/tmpl/internal/values.tpl
+++ b/module/deployment/tmpl/internal/values.tpl
@@ -3,12 +3,19 @@ enabled: true
 # Service
 mongodb:
     enabled: true
+    pvc:
+        storageClassName: null # You must specify a storage class name. Otherwise, the mongodb pod will not use pvc.
+        accessModes: 
+            - "ReadWriteOnce"
+        requests:
+            storage: 8Gi
 redis:
     enabled: true
 consul:
     enabled: true
     server:
         replicas: 3
+        #storageClass: null
     ui:
         enabled: false
 

--- a/module/deployment/tmpl/internal/values.tpl
+++ b/module/deployment/tmpl/internal/values.tpl
@@ -17,7 +17,7 @@ identity:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/identity
-      version: 1.9.7
+      version: 1.9.7.3
 
     pod:
         spec: {}
@@ -27,7 +27,7 @@ secret:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/secret
-      version: 1.9.7
+      version: 1.9.7.1
     application_grpc:
         BACKEND: ConsulConnector
         CONNECTORS:
@@ -47,14 +47,14 @@ repository:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/repository
-      version: 1.9.7
+      version: 1.9.7.1
 
 plugin:
     enabled: true
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/plugin
-      version: 1.9.7
+      version: 1.9.7.2
  
     scheduler: true
     worker: true
@@ -74,7 +74,7 @@ config:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/config
-      version: 1.9.7
+      version: 1.9.7.1
 
     pod:
         spec: {}
@@ -85,7 +85,7 @@ inventory:
     replicas_worker: 2
     image:
       name: public.ecr.aws/megazone/spaceone/inventory
-      version: 1.9.7
+      version: 1.9.7.2
     scheduler: true
     worker: true
     application_grpc:
@@ -163,7 +163,7 @@ monitoring:
     replicas_worker: 1
     image:
       name: public.ecr.aws/megazone/spaceone/monitoring
-      version: 1.9.7
+      version: 1.9.7.1
     application_grpc:
       WEBHOOK_DOMAIN: https://monitoring_webhook_domain
 #      TOKEN: __CHANGE_YOUR_ROOT_TOKEN___
@@ -231,7 +231,7 @@ statistics:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/statistics
-      version: 1.9.7
+      version: 1.9.7.1
  
     scheduler: true
     worker: true
@@ -251,7 +251,7 @@ notification:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/notification
-      version: 1.9.7
+      version: 1.9.7.1
     application_grpc:
         INSTALLED_PROTOCOL_PLUGINS:
           - name: Slack
@@ -286,7 +286,7 @@ cost-analysis:
     replicas_worker: 2
     image:
       name: public.ecr.aws/megazone/spaceone/cost-analysis
-      version: 1.9.7
+      version: 1.9.7.1
 
     # Overwrite scheduler config
     application_scheduler:
@@ -294,15 +294,13 @@ cost-analysis:
 
     application_grpc:
         DEFAULT_EXCHANGE_RATE:
-            KRW: 1178.7
-            JPY: 114.2
-            CNY: 6.3
+            KRW: 1242.7
+            JPY: 129.8
 
     application_worker:
         DEFAULT_EXCHANGE_RATE:
-            KRW: 1178.7
-            JPY: 114.2
-            CNY: 6.3
+            KRW: 1242.7
+            JPY: 129.8
 
     volumeMounts:
         application: []

--- a/module/deployment/tmpl/internal/values.tpl
+++ b/module/deployment/tmpl/internal/values.tpl
@@ -17,7 +17,7 @@ identity:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/identity
-      version: 1.9.6
+      version: 1.9.7
 
     pod:
         spec: {}
@@ -27,7 +27,7 @@ secret:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/secret
-      version: 1.9.6
+      version: 1.9.7
     application_grpc:
         BACKEND: ConsulConnector
         CONNECTORS:
@@ -47,14 +47,14 @@ repository:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/repository
-      version: 1.9.6
+      version: 1.9.7
 
 plugin:
     enabled: true
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/plugin
-      version: 1.9.6
+      version: 1.9.7
  
     scheduler: true
     worker: true
@@ -74,7 +74,7 @@ config:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/config
-      version: 1.9.6
+      version: 1.9.7
 
     pod:
         spec: {}
@@ -85,7 +85,7 @@ inventory:
     replicas_worker: 2
     image:
       name: public.ecr.aws/megazone/spaceone/inventory
-      version: 1.9.6
+      version: 1.9.7
     scheduler: true
     worker: true
     application_grpc:
@@ -163,7 +163,7 @@ monitoring:
     replicas_worker: 1
     image:
       name: public.ecr.aws/megazone/spaceone/monitoring
-      version: 1.9.6
+      version: 1.9.7
     application_grpc:
       WEBHOOK_DOMAIN: https://monitoring_webhook_domain
 #      TOKEN: __CHANGE_YOUR_ROOT_TOKEN___
@@ -231,7 +231,7 @@ statistics:
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/statistics
-      version: 1.9.6
+      version: 1.9.7
  
     scheduler: true
     worker: true
@@ -246,22 +246,12 @@ statistics:
     pod:
         spec: {}
 
-billing:
-    enabled: true
-    replicas: 1
-    image:
-      name: public.ecr.aws/megazone/spaceone/billing
-      version: 1.9.6
-
-    pod:
-        spec: {}
-
 notification:
     enabled: true
     replicas: 1
     image:
       name: public.ecr.aws/megazone/spaceone/notification
-      version: 1.9.6
+      version: 1.9.7
     application_grpc:
         INSTALLED_PROTOCOL_PLUGINS:
           - name: Slack
@@ -296,7 +286,7 @@ cost-analysis:
     replicas_worker: 2
     image:
       name: public.ecr.aws/megazone/spaceone/cost-analysis
-      version: 1.9.6
+      version: 1.9.7
 
     # Overwrite scheduler config
     application_scheduler:
@@ -333,7 +323,7 @@ supervisor:
     enabled: true
     image:
       name: public.ecr.aws/megazone/spaceone/supervisor
-      version: 1.9.6
+      version: 1.9.7
     application: {}
     application_scheduler:
         NAME: root
@@ -374,7 +364,7 @@ ingress:
 spaceone-initializer:
     enabled: false
     image:
-        version: 1.9.6
+        version: 1.9.7
 
 domain-initialzer:
     enabled: false
@@ -426,18 +416,12 @@ global:
             StatisticsConnector:
                 endpoint:
                     v1: grpc://statistics:50051
-            BillingConnector:
-                endpoint:
-                    v1: grpc://billing:50051
             NotificationConnector:
                 endpoint:
                     v1: grpc://notification:50051
-            PowerSchedulerConnector:
+            CostAnalysisConnector:
                 endpoint:
-                    v1: grpc://power-scheduler:50051
-            SpotAutomationConnector:
-                endpoint:
-                    v1: grpc://spot-automation:50051
+                    v1: grpc://cost-analysis:50051/v1
         CACHES:
             default:
                 backend: spaceone.core.cache.redis_cache.RedisCache

--- a/module/initialization/tmpl/domain.tpl
+++ b/module/initialization/tmpl/domain.tpl
@@ -1,7 +1,7 @@
 enabled: true
 image:
     name: spaceone/spacectl
-    version: 1.9.6
+    version: 1.9.7
 main:
   import:
     - /root/spacectl/apply/root_domain.yaml 

--- a/module/initialization/tmpl/domain.tpl
+++ b/module/initialization/tmpl/domain.tpl
@@ -1,7 +1,7 @@
 enabled: true
 image:
     name: spaceone/spacectl
-    version: 1.9.7
+    version: 1.9.7.3
 main:
   import:
     - /root/spacectl/apply/root_domain.yaml 


### PR DESCRIPTION
### Category
- [x] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
- spaceone micro-service image version has been updated(1.9.7)
- spacectl always prints the output log in debug mode
- spaceone helm release always update to the latest version when adding helm chart
- (Non-official) mongodb and Consul pods can specify storage classes to use persistent volumes.

### Known issue
